### PR TITLE
Allow overriding branches.sh without editing git tracked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /out/describe
 /build
 *.lock
+/branches-local

--- a/branches.sh
+++ b/branches.sh
@@ -2,6 +2,10 @@
 DIR=$(dirname $0)
 cd "$DIR/build"
 
+if [ -x ../branches-local ]; then
+    exec ../branches-local "$@"
+fi
+
 if [ "$1" = "-v" ]; then
 	VERBOSE=1
 else


### PR DESCRIPTION
Hi. I added a simple hook to let me deploy gitbuilder with custom things, while still keeping the gitbuilder clone "git status" clean. Everything else seemed to allow this already (build.sh etc), but branches.sh was a bit too hardcoded. Now it'll look for a "branches-local" script and execute that instead.

I also did not name it *.sh as I think I might write mine in python, and frankly gitbuilder just doesn't care, as long as it's executable.

Let me know what you think.
