### PR TITLE
Allow branch-specific build scripts

### DIFF
--- a/README
+++ b/README
@@ -167,7 +167,9 @@ gitbuilder works.  Here we go:
 	  See build.sh.example.
 
 	branches.sh: get a list of interesting branches in the build/
-	  directory.
+	  directory.  If the file "branches.txt" exists in the "gitbuilder"
+	  directory, it uses the branches listed there (one per line), instead
+	  of building all of the branches. 
 	  
 	revlist.sh: given a branch name, gets a list of all the revisions
 	  starting from that branch's HEAD and stopping at the first

--- a/autobuilder.sh
+++ b/autobuilder.sh
@@ -49,7 +49,7 @@ while [ -n "$did_something" ]; do
 		did_something=1
 		echo "Building $branch: $ref"
 		set -m
-		./runtee log.out ./run-build.sh $ref &
+		./runtee log.out ./run-build.sh $ref $branch &
 		XPID=$!
 		trap "echo 'Killing (SIGINT)';  kill -TERM -$XPID; exit 1" SIGINT
 		trap "echo 'Killing (SIGTERM)'; kill -TERM -$XPID; exit 1" SIGTERM

--- a/branches.sh
+++ b/branches.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+if [ -f ./branches.txt ]; then
+	cat branches.txt
+	exit 0
+fi
+
 DIR=$(dirname $0)
 cd "$DIR/build"
 

--- a/run-build.sh
+++ b/run-build.sh
@@ -7,6 +7,7 @@ if [ -z "$1" ]; then
 fi
 
 ref="$1"
+branch="$2"
 
 mkdir -p out/fail out/pass
 chmod 777 out/fail
@@ -35,7 +36,12 @@ _run()
 	git clean -q -f -x -d || return 30
 	
 	log "Building..."
-	../build.sh 2>&1 || return 40
+	# Prefer a branch-specific build over a generic one.
+	if [ -x ../build-$branch.sh ]; then
+		../build-$branch.sh 2>&1 || return 40
+	else
+		../build.sh 2>&1 || return 40
+	fi
 	
 	log "Done at: $(date)"
 	return 0


### PR DESCRIPTION
It's sometimes useful to have different build scripts for different branches.

The "build.sh" script is used by default.  However, if a "build-$BRANCH.sh" script is defined,
that script is used instead.

We use this locally to build with different compliation flags, or for cross-compiling.

It would be useful to extend gitbuilder to have multiple builds for one branch:

  ./configure --enable-foo

versus

  ./configure --disable-foo

It's not clear to me how this can be done with the current framework.   The pass/fail status is per commit, not per "variant of commit"
