### PR TITLE
make git remote update time out after 60 seconds

### DIFF
--- a/autobuilder.sh
+++ b/autobuilder.sh
@@ -33,8 +33,8 @@ chmod a+w out/errcache
 did_something=1
 while [ -n "$did_something" ]; do
 	( cd build && 
-	  git remote show | xargs git remote prune && 
-	  git remote update )
+	  git remote show | ./maxtime 60 xargs git remote prune &&
+	  ./maxtime 60 git remote update )
 	did_something=
 	for branch in $(./branches.sh); do
 		ref=$(./next-rev.sh $branch)


### PR DESCRIPTION
We've used /usr/bin/timeout for a while for this, to make the gitbuilder not hang even when Github goes for a coffee break, but I just realized you already include maxtime so this is doable without external dependencies, so I'm submitting this pull request now.

(Now, whether that should be 60 seconds or something else is debatable. And should it be configurable? But the need is definitely there.)
