### PR TITLE
Fixed a segmentation fault happening in next-rev.sh

### DIFF
--- a/next-rev.sh
+++ b/next-rev.sh
@@ -4,7 +4,7 @@ cd "$DIR/build"
 
 bisect()
 {
-	(git rev-list --first-parent --bisect-all "$@" ||
+	(git rev-list --bisect-all "$@" ||
 	 git rev-list --first-parent "$@" ) |
 		while read x y; do
 			[ -e ../out/pass/$x -o -e ../out/fail/$x ] && continue


### PR DESCRIPTION
...s causing seg fault.

The seg fault happens when the git log has the following structure:

|
|
|
|
|
- commit ed369
  |
  |     Some message 2
  |
- commit 4e900
  |
  |     Some message 3
  |
-   commit 860f4
  |\  Merge: 56a231b cc6068c
  | |
  | |     Merge branch 'xxxx' of yyyy into zzzz
  | |
  | \* commit c7cb8
  | |
  | |     Some message 4
  | |
- | commit 7951d
  |/  Author:
  |   Date:
  |

And the bisect call in next-rev.sh looks like:
    bisect 75980^ ^7951d

So to repro segmentation fault, one can issue the following command-line:
    git rev-list --first-parent --bisect-all 75980^ ^7951d --

(Please replace truncated hash IDs with full hash IDs everywhere.)
